### PR TITLE
Fixed bugs related to reading and added installation instructions for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,77 @@ Players play the game by typing commands such as `take the rusty sword` and `go 
 
 ## Coding
 The coding of the game is primarily in python 3, and hosts a server that players can log onto using telnet. The server is writen using twisted (twistedmatrix.com) and allows multiple players to log on and interact using asynchronous operation. 
+
+## Installation (Linux)
+> _These instructions were tested on Linux Mint 18 which is based on Ubuntu 16.04. Other flavors of Linux may follow similar steps_
+
+**NOTICE:** This game is in the early stages of development and, therefore, is prone to buggy behavior and is rampant with half finished content. These instructions are here primarily for those who are either interested in contributing or simply curious to see how the project is progressing. Do not install this expecting to find a completed and polished game just yet. That is still a ways down the road.
+
+### Dependency installation 
+```
+sudo apt-get install python3 python3-dev python3-pip
+
+# upgrade pip
+sudo pip3 --upgrade pip
+
+# install twisted.internet
+sudo pip3 install setuptools
+sudo pip3 install twisted[tls]
+
+# check for unmet dependencies
+pip3 check
+
+# fix any unmet dependencies
+sudo pip3 install cryptography
+sudo pip3 install pyasn1-modules
+```
+Please note that unmet dependencies revealed by the `pip3 check` command may be reliant on each other. As such, if one refuses to update, it may be because another must be updated first. Try installing the rest, and then retry any that had failed previously.
+
+### Downloading the source code
+If you have git installed on your computer you can clone the git repository to your hard drive by opening a terminal to the folder you wish to keep it in and typing:
+
+`git clone https://github.com/davedotluebke/old-skool-text-game.git`
+
+Alternatively, you can:
+1. Go to [https://github.com/davedotluebke/old-skool-text-game](https://github.com/davedotluebke/old-skool-text-game)
+2. Click the green button that says "Clone or download"
+3. Select "Download ZIP"
+4. Extract the files wherever you want the game to be located.
+
+### Running the game
+This is a server game, and as such, you must first start a server application and then connect to it as a client.
+
+#### Starting the server
+To start the game server, open a terminal to the git source directory and type:
+
+`python3 OAD.TextGame.py`
+
+#### Joining the server
+telnet:
+> Telnet is the simplest way to connect but does have its drawbacks. For instance, if the server displays a message while you are typing, the screen will scroll, taking half of your command string with it. That will prevent you from using `<backspace>` to make changes to what you've already typed.
+
+To join the game server using `telnet`, simply open another terminal and type:
+
+`telnet localhost 9123`
+
+***
+
+[kbtin](https://github.com/kilobyte/kbtin):
+
+> Kbtin is a terminal-based MUD client. It comes packed with many features, but the simplest and greatest is simply that it prevents the output from the server from interfering with the commands you are typing.
+
+To install kbtin, type:
+
+`sudo apt-get install kbtin`
+
+For convenience you may wish to create a short script file for loading the game. In your home directory, create a file called `oad`. In it, put the following:
+
+```
+#charset UTF-8
+#session OAD localhost 9123
+```
+
+In order to join the server, open a terminal to your home folder and type:
+
+`kbtin oad`
+

--- a/book.py
+++ b/book.py
@@ -12,28 +12,25 @@ class Book(Thing):
         self.add_names('book')
 
     def set_message(self, message):
-        page_num = 0
-        c = 0
-        page = '\n'
-        for i in message.splitlines(True):
-            if i == "#*\n":
-                page_num += 1
-                c = 0
-                try:
-                    self.what_you_read[page_num] = page
-                except IndexError:
-                    self.what_you_read.append(page)
-                page = '\n'
+        self.what_you_read = list()
+        page_text = '\n'
+
+        for line_text in message.splitlines(True):
+            if line_text.strip(' \t\r\n') == "#*": 
+                ## page break ##
+                self.what_you_read.append(page_text)
+                page_text = '\n'
                 continue
-            page += i
-            c += 1
-            # #* means page break
-        try:
-            self.what_you_read[page_num] = (page + '\n\n')
-        except IndexError:
-            self.what_you_read.append(page + '\n\n')
+            page_text += line_text 
+
+        self.what_you_read.append(page_text + '\n\n')
 
     def read(self, p, cons, oDO, oIDO):
+        '''
+            case == 1: read current page
+            case == 2: read specific page
+            case == 3: read next page
+        '''
         if self not in cons.user.contents:
             cons.write('You need to take the book before reading it!')
             return True
@@ -44,40 +41,64 @@ class Book(Thing):
                 case = 3
             else:
                 case = 1
-        # see if they typed "read page #" 
-        match = re.search(r'page (\d+)', sDO)
-        if match:
-            pagenum = match.group(1)
-            case = 2
+
         if not case:
-            match = re.search(r'next page', sDO)
+            # search the direct object string (sDO) to determine which page to read
+            match = re.search(r'page (\d+)', sDO)
             if match:
+                #> read page #
+                pagenum = match.group(1)
+                case = 2
+            elif re.search(r'next page', sDO):
+                #> read next page
                 case = 3
-            if not case:
-                match = re.search(r'page', sDO)
-                if match:
-                    case = 1
-                if not case:
-                    match = re.search(r'(\S+)', sDO)
-                    if match:
-                        if match.group(1) in self.names:
-                            case = 1
-        try:
-            if self.what_you_read and (case == 1):
-                cons.write("You read:"+str(self.what_you_read[self.index]), 8)
-                cons.user.reading = True
-            elif self.what_you_read and (case == 2):
-                self.index = int(pagenum)-1
-                cons.write('You flip to page '+str(self.index+1)+'.')
-                cons.write("You read:"+str(self.what_you_read[self.index]), 8)
-                cons.user.reading = True
-            elif self.what_you_read and (case == 3):
-                self.index += 1
-                cons.write("You read:"+str(self.what_you_read[self.index]), 8)
-                cons.user.reading = True
+            elif re.search(r'page', sDO):
+                #> read page
+                case = 1
             else:
-                cons.write("A problem occured!")
-            cons.user.emit("&nD%s reads from the %s." %(cons.user.id, self.s_desc))
+                match = re.search(r'(\S+)', sDO)
+
+                if match and match.group(1) in self.names:
+                    #> read [this book's name]
+                    case = 1
+        try:
+            can_read = True
+
+            # select the appropriate page to read
+            if not self.what_you_read:
+                # there's nothing to read
+                can_read = False
+                cons.write("It appears to be blank...")
+                cons.user.emit("&nD%s stares confusedly at the %s." %(cons.user.id, self.short_desc))
+            elif (case == 2):
+                if 0 < int(pagenum) <= len(self.what_you_read):
+                    if (self.index != int(pagenum)-1):
+                        # not the same page as last time
+                        self.index = int(pagenum)-1
+                        cons.write('You flip to page ' + str(self.index+1) + '.')
+                else:
+                    raise IndexError
+            elif (case == 3):
+                if (self.index+1 == len(self.what_you_read)):
+                    can_read = False
+                else: 
+                    self.index += 1
+
+            if can_read:
+                cons.write("You read:" + str(self.what_you_read[self.index]), 8)
+                if not cons.user.reading:
+                    cons.user.emit("&nD%s opens the %s and starts to read." %(cons.user.id, self.short_desc))
+                else:
+                    cons.user.emit("&nD%s flips through the pages of the %s thoughtfully." %(cons.user.id, self.short_desc))
+                cons.user.reading = True
+            elif not self.what_you_read:
+                # blank book
+                cons.write("It appears to be blank...")
+                cons.user.emit("&nD%s stares confusedly at the %s." %(cons.user.id, self.short_desc))
+            else:
+                # end of book
+                cons.write("There's nothing left to read.")
+
         except IndexError:
-            cons.write('The book does not have a page numbered %s!' % str(self.index+1))
+            cons.write("You can't seem to find that page...")
         return True

--- a/domains/school/school/blue_book.py
+++ b/domains/school/school/blue_book.py
@@ -6,60 +6,59 @@ def clone():
     blue_book.add_adjectives("blue", "newer", "light")
     blue_book.set_message('''
 
-    Dragonsky
+Dragonsky
 
-    by Owen Luebke
-    #*
-    Chapter 1
-        Once upon a time there were two twins. One was named Skylar, and the other was named Jennifer. They were each other’s best friends, too. They both enjoyed writing. Skylar wrote mostly poetry, and Jennifer wrote some non-fiction and a lot of autobiography, which was in a long book she wrote about her and Skylar’s lives. Her book stretched back to when she first learned to write at age 3, quite early. Their local elementary school was very supportive of their writing, and they were happy there.
-        Skylar and Jennifer happened to live in Kenshalk, and it was a great fit for them. Jennifer wrote a lot about the historic buildings, and they both enjoyed the brightly colored streetcars. They even lived in one of the houses overlooking the expansive KTA museum and the tracks beyond. 
-        Skylar and Jennifer had many adventures. Occasionally, they went camping, or they would visit places in town. They even went to other cities sometimes. They liked adventures almost anywhere.
-        They had a treehouse up in one of the trees near the fence. They were not afraid of heights at all. In fact, they enjoyed feeling like they were flying from a high height. Sometimes they sat up in the treehouse and wrote things. Skylar wrote many poems there, such as:
-            The wind rustles the leaves
-            In the spring
-            And it seems like fall
+by Owen Luebke
+#*
+Chapter 1
+    Once upon a time there were two twins. One was named Skylar, and the other was named Jennifer. They were each other’s best friends, too. They both enjoyed writing. Skylar wrote mostly poetry, and Jennifer wrote some non-fiction and a lot of autobiography, which was in a long book she wrote about her and Skylar’s lives. Her book stretched back to when she first learned to write at age 3, quite early. Their local elementary school was very supportive of their writing, and they were happy there.
+    Skylar and Jennifer happened to live in Kenshalk, and it was a great fit for them. Jennifer wrote a lot about the historic buildings, and they both enjoyed the brightly colored streetcars. They even lived in one of the houses overlooking the expansive KTA museum and the tracks beyond. 
+    Skylar and Jennifer had many adventures. Occasionally, they went camping, or they would visit places in town. They even went to other cities sometimes. They liked adventures almost anywhere.
+    They had a treehouse up in one of the trees near the fence. They were not afraid of heights at all. In fact, they enjoyed feeling like they were flying from a high height. Sometimes they sat up in the treehouse and wrote things. Skylar wrote many poems there, such as:
+        The wind rustles the leaves
+        In the spring
+        And it seems like fall
 
-            The sun glares down
-            In the spring
-            And it seems like summer
+        The sun glares down
+        In the spring
+        And it seems like summer
 
-            The bare trees sit
-            In the spring
-            And it seems like winter
+        The bare trees sit
+        In the spring
+        And it seems like winter
 
-            Then the trees bloom
-            In the spring
-            And it seems like spring
-        They were preparing for their 12th birthday party. They were born in May, and so it happened as the school year let out. It was at
-    #*
-    Bounce Away!® because they liked to feel like they were flying, and the trampoline park did a pretty good job. Their entire class was invited, as well as some 4th graders and siblings of friends. It was a big group, and miraculously everyone could come. It was a really exciting event for everyone.
-        The day of the party was dreary and wet, but warm, so Skylar and Jennifer were happy they chose an indoor activity. Waiting at stoplight after stoplight on route 95 only made them more and more excited. When they arrived, they met everybody else quickly, and went in. The party had started.
-        They had a great time. They raced around, and they bounced in circles. And they tried to see who could jump the highest. Skylar and Jennifer were winning against everyone else. And they started jumping higher and higher. Then they both, at the same time, stuck out their arms and jumped even higher, and then started moving onto other trampolines. “Wee! We’re flying!” said Skylar. And then everyone started pretending to fly, and zipped around with their arms out. Skylar and Jennifer were bouncing so crazily that they had a hard time stopping before they went to their house for cake and ice cream.
+        Then the trees bloom
+        In the spring
+        And it seems like spring
+    They were preparing for their 12th birthday party. They were born in May, and so it happened as the school year let out. It was at
+#*
+Bounce Away!® because they liked to feel like they were flying, and the trampoline park did a pretty good job. Their entire class was invited, as well as some 4th graders and siblings of friends. It was a big group, and miraculously everyone could come. It was a really exciting event for everyone.
+    The day of the party was dreary and wet, but warm, so Skylar and Jennifer were happy they chose an indoor activity. Waiting at stoplight after stoplight on route 95 only made them more and more excited. When they arrived, they met everybody else quickly, and went in. The party had started.
+    They had a great time. They raced around, and they bounced in circles. And they tried to see who could jump the highest. Skylar and Jennifer were winning against everyone else. And they started jumping higher and higher. Then they both, at the same time, stuck out their arms and jumped even higher, and then started moving onto other trampolines. “Wee! We’re flying!” said Skylar. And then everyone started pretending to fly, and zipped around with their arms out. Skylar and Jennifer were bouncing so crazily that they had a hard time stopping before they went to their house for cake and ice cream.
 
-        That night, as they lay in their beds, they talked about the day.
-        “My favorite part was pretending to fly,” said Jennifer.
-        “I agree. We jumped really high.” said Skylar.
-        “We did. It was a good thing we didn’t hit the ceiling.”
-        “It reminded me of when we first jumped on a trampoline when we were 3.”
-        “Yeah. It was almost like we were actually flying.”
-        Skylar did not respond right away. His mind went to the trampoline at age 3, to an experience where he fell down a few stairs, and to today. When he replied, it was in a whisper. He said:
-        “I think maybe we can fly.”
-        “Maybe,” Jennifer whispered back, after a short pause.
-        “After another short pause, Skylar said, “I’m going to try.”
-        He got out of bed, and stood in the middle of the room. He just stood there for a second, then he moved his arms up and down. Slowly but surely, he rose off the ground. Jennifer just stared.
-        Then Jennifer got out of bed, and moved her arms up and down. She, too, went slowly but surely up into the air. They both looked at each other. 
-        “Come on, let’s fly to the tree house!” said Skylar. He and Jennifer shoved open the old window, trying to keep it from squeaking or slamming shut on them. Eventually, they forced it open, and wedged it open. They both stepped out onto the windowsill. 
-    #*
-        The warm rain drizzled down on them. It was not very strong anymore, just a little harder than mist. The ground was moist, visible from the second story window. It drizzled on.
-        Skylar and Jennifer both stood for a second on the windowsill, gazing out upon the woods, before they took off into the rainy night. Flying down to the treehouse, they twisted and turned and fell in crazy somersaults. They rocketed up and down, right and left, and broke a few small branches. They tried to aim for the treehouse, but it was no good. They went up above the treehouse. Skylar came to a stop. He stood there for a second and looked out.
-        Unfortunately, Jennifer’s landing was unexpected. She was a foot over the treehouse roof when she just dropped. “Ow!” she said quietly
-        “I’ve got one thing I want you to agree to,” said Skylar in a hushed voice.
-        “Is it ‘Don’t tell anyone’?” Jennifer whispered back.
-        “Yes!” replied Skylar.
-        They looked out over the KTA train museum and Banké Pacific tracks. No trains were running at the KTA museum, and one battered boxcar was sitting in the shadows on the Banké Pacific tracks. It said, “Banké Pacific Freight Express” and looked forlorn by itself.
-        An occasional car zipped past about once a minute on the road. The bright lights and sound of the wheels on the asphalt, as well as the new pavement and bright lines, made the road seem more active and important than the tracks and museum. The streetlights shone down brightly.
-        The warm rain trickled down, and the sound of dripping filled the air. It was light, but it was in a pattern almost, dripping as if it was part of a song. It was a nice sound, and dripped melodically.
-        Finally, Skylar and Jennifer departed back to their house. They went shooting up in the air as soon as they took off, and then tore straight for their windowsill. Skylar had to kick off the brick to stop himself. Then they slid into their room, jiggled their window down, trying to keep it from slamming or squeaking, and jumped back into their beds, where they lay wondering what they had discovered.
-    #*
-    ''')
+    That night, as they lay in their beds, they talked about the day.
+    “My favorite part was pretending to fly,” said Jennifer.
+    “I agree. We jumped really high.” said Skylar.
+    “We did. It was a good thing we didn’t hit the ceiling.”
+    “It reminded me of when we first jumped on a trampoline when we were 3.”
+    “Yeah. It was almost like we were actually flying.”
+    Skylar did not respond right away. His mind went to the trampoline at age 3, to an experience where he fell down a few stairs, and to today. When he replied, it was in a whisper. He said:
+    “I think maybe we can fly.”
+    “Maybe,” Jennifer whispered back, after a short pause.
+    “After another short pause, Skylar said, “I’m going to try.”
+    He got out of bed, and stood in the middle of the room. He just stood there for a second, then he moved his arms up and down. Slowly but surely, he rose off the ground. Jennifer just stared.
+    Then Jennifer got out of bed, and moved her arms up and down. She, too, went slowly but surely up into the air. They both looked at each other. 
+    “Come on, let’s fly to the tree house!” said Skylar. He and Jennifer shoved open the old window, trying to keep it from squeaking or slamming shut on them. Eventually, they forced it open, and wedged it open. They both stepped out onto the windowsill. 
+#*
+    The warm rain drizzled down on them. It was not very strong anymore, just a little harder than mist. The ground was moist, visible from the second story window. It drizzled on.
+    Skylar and Jennifer both stood for a second on the windowsill, gazing out upon the woods, before they took off into the rainy night. Flying down to the treehouse, they twisted and turned and fell in crazy somersaults. They rocketed up and down, right and left, and broke a few small branches. They tried to aim for the treehouse, but it was no good. They went up above the treehouse. Skylar came to a stop. He stood there for a second and looked out.
+    Unfortunately, Jennifer’s landing was unexpected. She was a foot over the treehouse roof when she just dropped. “Ow!” she said quietly
+    “I’ve got one thing I want you to agree to,” said Skylar in a hushed voice.
+    “Is it ‘Don’t tell anyone’?” Jennifer whispered back.
+    “Yes!” replied Skylar.
+    They looked out over the KTA train museum and Banké Pacific tracks. No trains were running at the KTA museum, and one battered boxcar was sitting in the shadows on the Banké Pacific tracks. It said, “Banké Pacific Freight Express” and looked forlorn by itself.
+    An occasional car zipped past about once a minute on the road. The bright lights and sound of the wheels on the asphalt, as well as the new pavement and bright lines, made the road seem more active and important than the tracks and museum. The streetlights shone down brightly.
+    The warm rain trickled down, and the sound of dripping filled the air. It was light, but it was in a pattern almost, dripping as if it was part of a song. It was a nice sound, and dripped melodically.
+    Finally, Skylar and Jennifer departed back to their house. They went shooting up in the air as soon as they took off, and then tore straight for their windowsill. Skylar had to kick off the brick to stop himself. Then they slid into their room, jiggled their window down, trying to keep it from slamming or squeaking, and jumped back into their beds, where they lay wondering what they had discovered.
+''')
     return blue_book

--- a/parse.py
+++ b/parse.py
@@ -175,6 +175,10 @@ class Parser:
         sPrep = None         # Preposition as string
         (sV, sDO, sPrep, sIDO) = self.diagram_sentence(self.words)
 
+        if console.user.reading and (sV != "read") and (sV != "close"):
+            # stop reading if any other action is performed
+            console.user.reading_object.close(user, console, console.user.reading_object, None);
+
         # FIRST, search for objects that support the verb the user typed
             # TODO: only include room contents if room is not dark (but always include user)
         possible_objects = [user.location] 
@@ -207,7 +211,11 @@ class Parser:
             oIDO = self._find_matching_objects(sIDO, possible_objects, console)
         if oDO == False or oIDO == False: 
             return True     # ambiguous user input; >1 object matched 
-         
+
+        # to avoid reading the wrong book, use the last read book when not specified         
+        if (sV == "read") and not oDO and console.user.reading_object:
+            oDO = console.user.reading_object
+
         # If direct or indirect object supports the verb, try first in that order
         initial_actions = []
         for o in (oDO, oIDO):

--- a/player.py
+++ b/player.py
@@ -41,6 +41,7 @@ class Player(Creature):
         self.wizardry_element = None
         self.attacking = False
         self.reading = False
+        self.reading_object = None
         self.hitpoints = 20
         self.health = 20
         self.terse = False  # True -> show short description when entering room

--- a/thing.py
+++ b/thing.py
@@ -218,7 +218,7 @@ class Thing(object):
 
     def move_to(self, dest, force_move=False):
         """Extract this object from its current location and insert into dest. 
-        Returns True if the move succeds. If the insertion fails, attempts to 
+        Returns True if the move succeeds. If the insertion fails, attempts to 
         re-insert into the original location and returns False.  
         If <force_move> is True, ignores the <fixed> attribute."""
         origin = self.location
@@ -256,10 +256,10 @@ class Thing(object):
         if self.fixed:      return self.fixed
         if self.location != cons.user: return "You aren't holding the %s!" % self.short_desc
         if self.move_to(cons.user.location):
-            cons.write("You drop the %s." % self)
-            cons.user.emit("&nD%s drops the %s." % cons.user.id, self)
+            cons.write("You drop the %s." % self.short_desc)
+            cons.user.emit("&nD%s drops the %s." % (cons.user.id, self.short_desc))
         else:
-            cons.write("You cannot drop the %s" % self)
+            cons.write("You cannot drop the %s" % self.short_desc)
         return True
 
     def look_at(self, p, cons, oDO, oIDO):  


### PR DESCRIPTION
I fleshed out the reading system as it applies to book.py. 
- The page break marker, '#*', no longer has to be strictly at the beginning of the line nor have a newline immediately after. 
- Books can now be 'closed' so that others can be placed into 'reading' mode. 
- When books are dropped the page index resets to 0 so that the next person to pick it up will start reading from page one instead of where the last person left off.
- There are more emits associated with reading.

I also wrote some installation instructions for Linux Mint 18/Ubuntu 16.04.